### PR TITLE
deallocate on drop

### DIFF
--- a/benches/compare_std_vec.rs
+++ b/benches/compare_std_vec.rs
@@ -9,15 +9,22 @@ use test::Bencher;
 #[derive(Clone, Debug, PartialEq)]
 #[repr(align(128))]
 struct TestA {
-    a: u32,
+    a: usize,
     b: usize,
     c: usize,
 }
 
-#[bench]
-fn test_header_vec_create(b: &mut Bencher) {
+#[derive(Clone, Debug, PartialEq)]
+struct TestAWithoutAlign {
+    a: usize,
+    b: usize,
+    c: usize,
+}
+
+
+fn bench_with_header<H:Clone>(h:H, b: &mut Bencher){
     b.iter(|| {
-        let mut v = HeaderVec::<TestA, usize>::new(TestA { a: 4, b: !0, c: 66 });
+        let mut v = HeaderVec::<_, usize>::new(h.clone());
         const N_ELEMENTS: usize = 1000;
         for i in 0..N_ELEMENTS {
             v.push(i);
@@ -28,38 +35,27 @@ fn test_header_vec_create(b: &mut Bencher) {
 
 #[bench]
 fn test_header_vec_with_zst_create(b: &mut Bencher) {
-    b.iter(|| {
-        let mut v = HeaderVec::<(), usize>::new(());
-        const N_ELEMENTS: usize = 1000;
-        for i in 0..N_ELEMENTS {
-            v.push(i);
-        }
-        v
-    });
+    bench_with_header((), b);
 }
 
 #[bench]
-fn test_header_vec_with_u64_create(b: &mut Bencher) {
-    b.iter(|| {
-        let mut v = HeaderVec::<u64, usize>::new(2u64);
-        const N_ELEMENTS: usize = 1000;
-        for i in 0..N_ELEMENTS {
-            v.push(i);
-        }
-        v
-    });
+fn test_header_vec_with_one_word_create(b: &mut Bencher) {
+    bench_with_header(2usize, b);
 }
 
 #[bench]
 fn test_header_vec_with_three_word_create(b: &mut Bencher) {
-    b.iter(|| {
-        let mut v = HeaderVec::<(u64, u64, u64), usize>::new((2, 2, 2));
-        const N_ELEMENTS: usize = 1000;
-        for i in 0..N_ELEMENTS {
-            v.push(i);
-        }
-        v
-    });
+    bench_with_header((2usize, 2usize, 2usize), b);
+}
+
+#[bench]
+fn test_header_vec_with_test_a_create(b: &mut Bencher) {
+    bench_with_header(TestA{ a:1, b:1, c:1 }, b);
+}
+
+#[bench]
+fn test_header_vec_with_test_a_without_align_create(b: &mut Bencher) {
+    bench_with_header(TestAWithoutAlign{ a:1, b:1, c:1 }, b);
 }
 
 #[bench]

--- a/benches/compare_std_vec.rs
+++ b/benches/compare_std_vec.rs
@@ -51,6 +51,18 @@ fn test_header_vec_with_u64_create(b: &mut Bencher) {
 }
 
 #[bench]
+fn test_header_vec_with_three_word_create(b: &mut Bencher) {
+    b.iter(|| {
+        let mut v = HeaderVec::<(u64, u64, u64), usize>::new((2, 2, 2));
+        const N_ELEMENTS: usize = 1000;
+        for i in 0..N_ELEMENTS {
+            v.push(i);
+        }
+        v
+    });
+}
+
+#[bench]
 fn test_regular_vec_create(b: &mut Bencher) {
     b.iter(|| {
         let mut v = Vec::<usize>::new();

--- a/benches/compare_std_vec.rs
+++ b/benches/compare_std_vec.rs
@@ -21,8 +21,7 @@ struct TestAWithoutAlign {
     c: usize,
 }
 
-
-fn bench_with_header<H:Clone>(h:H, b: &mut Bencher){
+fn bench_with_header<H: Clone>(h: H, b: &mut Bencher) {
     b.iter(|| {
         let mut v = HeaderVec::<_, usize>::new(h.clone());
         const N_ELEMENTS: usize = 1000;
@@ -50,12 +49,12 @@ fn test_header_vec_with_three_word_create(b: &mut Bencher) {
 
 #[bench]
 fn test_header_vec_with_test_a_create(b: &mut Bencher) {
-    bench_with_header(TestA{ a:1, b:1, c:1 }, b);
+    bench_with_header(TestA { a: 1, b: 1, c: 1 }, b);
 }
 
 #[bench]
 fn test_header_vec_with_test_a_without_align_create(b: &mut Bencher) {
-    bench_with_header(TestAWithoutAlign{ a:1, b:1, c:1 }, b);
+    bench_with_header(TestAWithoutAlign { a: 1, b: 1, c: 1 }, b);
 }
 
 #[bench]

--- a/benches/compare_std_vec.rs
+++ b/benches/compare_std_vec.rs
@@ -27,6 +27,30 @@ fn test_header_vec_create(b: &mut Bencher) {
 }
 
 #[bench]
+fn test_header_vec_with_zst_create(b: &mut Bencher) {
+    b.iter(|| {
+        let mut v = HeaderVec::<(), usize>::new(());
+        const N_ELEMENTS: usize = 1000;
+        for i in 0..N_ELEMENTS {
+            v.push(i);
+        }
+        v
+    });
+}
+
+#[bench]
+fn test_header_vec_with_u64_create(b: &mut Bencher) {
+    b.iter(|| {
+        let mut v = HeaderVec::<u64, usize>::new(2u64);
+        const N_ELEMENTS: usize = 1000;
+        for i in 0..N_ELEMENTS {
+            v.push(i);
+        }
+        v
+    });
+}
+
+#[bench]
 fn test_regular_vec_create(b: &mut Bencher) {
     b.iter(|| {
         let mut v = Vec::<usize>::new();
@@ -38,60 +62,60 @@ fn test_regular_vec_create(b: &mut Bencher) {
     });
 }
 
-#[bench]
-fn test_header_vec_create_smaller(b: &mut Bencher) {
-    b.iter(|| {
-        let mut v = HeaderVec::<TestA, usize>::new(TestA { a: 4, b: !0, c: 66 });
-        const N_ELEMENTS: usize = 100;
-        for i in 0..N_ELEMENTS {
-            v.push(i);
-        }
-        v
-    });
-}
+// #[bench]
+// fn test_header_vec_create_smaller(b: &mut Bencher) {
+//     b.iter(|| {
+//         let mut v = HeaderVec::<TestA, usize>::new(TestA { a: 4, b: !0, c: 66 });
+//         const N_ELEMENTS: usize = 100;
+//         for i in 0..N_ELEMENTS {
+//             v.push(i);
+//         }
+//         v
+//     });
+// }
 
-#[bench]
-fn test_regular_vec_create_smaller(b: &mut Bencher) {
-    b.iter(|| {
-        let mut v = Vec::<usize>::new();
-        const N_ELEMENTS: usize = 100;
-        for i in 0..N_ELEMENTS {
-            v.push(i);
-        }
-        v
-    });
-}
+// #[bench]
+// fn test_regular_vec_create_smaller(b: &mut Bencher) {
+//     b.iter(|| {
+//         let mut v = Vec::<usize>::new();
+//         const N_ELEMENTS: usize = 100;
+//         for i in 0..N_ELEMENTS {
+//             v.push(i);
+//         }
+//         v
+//     });
+// }
 
-#[bench]
-fn test_header_vec_read(b: &mut Bencher) {
-    let mut v = HeaderVec::<TestA, usize>::new(TestA { a: 4, b: !0, c: 66 });
-    const N_ELEMENTS: usize = 1000;
-    for i in 0..N_ELEMENTS {
-        v.push(i);
-    }
+// #[bench]
+// fn test_header_vec_read(b: &mut Bencher) {
+//     let mut v = HeaderVec::<TestA, usize>::new(TestA { a: 4, b: !0, c: 66 });
+//     const N_ELEMENTS: usize = 1000;
+//     for i in 0..N_ELEMENTS {
+//         v.push(i);
+//     }
 
-    b.iter(|| {
-        let mut acc = 0;
-        for i in 0..N_ELEMENTS {
-            acc += v[i];
-        }
-        acc
-    });
-}
+//     b.iter(|| {
+//         let mut acc = 0;
+//         for i in 0..N_ELEMENTS {
+//             acc += v[i];
+//         }
+//         acc
+//     });
+// }
 
-#[bench]
-fn test_regular_vec_read(b: &mut Bencher) {
-    let mut v = Vec::<usize>::new();
-    const N_ELEMENTS: usize = 1000;
-    for i in 0..N_ELEMENTS {
-        v.push(i);
-    }
+// #[bench]
+// fn test_regular_vec_read(b: &mut Bencher) {
+//     let mut v = Vec::<usize>::new();
+//     const N_ELEMENTS: usize = 1000;
+//     for i in 0..N_ELEMENTS {
+//         v.push(i);
+//     }
 
-    b.iter(|| {
-        let mut acc = 0;
-        for i in 0..N_ELEMENTS {
-            acc += v[i];
-        }
-        acc
-    });
-}
+//     b.iter(|| {
+//         let mut acc = 0;
+//         for i in 0..N_ELEMENTS {
+//             acc += v[i];
+//         }
+//         acc
+//     });
+// }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -249,8 +249,8 @@ impl<H, T> HeaderVec<H, T> {
     /// Gives the offset in units of T (as if the pointer started at an array of T) that the slice actually starts at.
     #[inline(always)]
     fn offset() -> usize {
-        // We need to first compute the first location we can start in align units.
-        // Then we go from align units to offset units using mem::align_of::<T>() / mem::size_of::<T>().
+        // The first location, in units of size_of::<T>(), that is after the header
+        // It's the end of the header, rounded up to the nearest size_of::<T>()
         (mem::size_of::<HeaderVecHeader<H>>() + mem::size_of::<T>() - 1) / mem::size_of::<T>()
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -308,6 +308,7 @@ impl<H, T> Drop for HeaderVec<H, T> {
             for ix in 0..self.len() {
                 ptr::drop_in_place(self.start_ptr_mut().add(ix));
             }
+            alloc::alloc::dealloc(self.ptr as *mut u8, Self::layout(self.capacity()));
         }
     }
 }


### PR DESCRIPTION
It turns out that... it wasn't being deallocated in `drop`.

It only occurred to me to look at this because my computer was entering swap hell every time I ran a benchmark. This seems to have been most of the cause of those bad benchmark results. I can't explain how it produced those particular figures so reliably, but the numbers have now fallen to ordinary ranges.