### PR TITLE
Feature spare elements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,7 @@ keywords = ["header", "heap", "vec", "vector", "graph"]
 categories = ["no-std"]
 license = "MIT"
 readme = "README.md"
+
+[features]
+default = ["atomic_append"]
+atomic_append = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -227,7 +227,7 @@ impl<H, T> HeaderVec<H, T> {
     pub fn reserve(&mut self, additional: usize) -> Option<*const ()> {
         if self.spare_capacity() < additional {
             let len = self.len_exact();
-            unsafe { self.resize_cold(len + additional, false) }
+            unsafe { self.resize_cold(len.saturating_add(additional), false) }
         } else {
             None
         }
@@ -238,7 +238,7 @@ impl<H, T> HeaderVec<H, T> {
     pub fn reserve_exact(&mut self, additional: usize) -> Option<*const ()> {
         if self.spare_capacity() < additional {
             let len = self.len_exact();
-            unsafe { self.resize_cold(len + additional, true) }
+            unsafe { self.resize_cold(len.saturating_add(additional), true) }
         } else {
             None
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -381,7 +381,7 @@ impl<H, T> HeaderVec<H, T> {
     const fn offset() -> usize {
         // The first location, in units of size_of::<T>(), that is after the header
         // It's the end of the header, rounded up to the nearest size_of::<T>()
-        mem::size_of::<AlignedHeader<H, T>>() / mem::size_of::<T>()
+        (mem::size_of::<AlignedHeader<H, T>>()-1) / mem::size_of::<T>() + 1
     }
 
     /// Compute the number of elements (in units of T) to allocate for a given capacity.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ use core::{
     mem::{self, ManuallyDrop},
     ops::{Deref, DerefMut, Index, IndexMut},
     ptr,
+    ptr::NonNull,
     slice::SliceIndex,
 };
 
@@ -51,7 +52,7 @@ union AlignedHeader<H, T> {
 /// All of the data, like our header `OurHeaderType { a: 2 }`, the length of the vector: `2`,
 /// and the contents of the vector `['x', 'z']` resides on the other side of the pointer.
 pub struct HeaderVec<H, T> {
-    ptr: *mut AlignedHeader<H, T>,
+    ptr: NonNull<AlignedHeader<H, T>>,
 }
 
 impl<H, T> HeaderVec<H, T> {
@@ -65,10 +66,10 @@ impl<H, T> HeaderVec<H, T> {
         let layout = Self::layout(capacity);
         let ptr = unsafe { alloc::alloc::alloc(layout) } as *mut AlignedHeader<H, T>;
 
-        // Handle out-of-memory.
-        if ptr.is_null() {
+        let Some(ptr) = NonNull::new(ptr) else {
+            // Handle out-of-memory.
             alloc::alloc::handle_alloc_error(layout);
-        }
+        };
 
         // Create self.
         let mut this = Self { ptr };
@@ -173,14 +174,14 @@ impl<H, T> HeaderVec<H, T> {
     /// This is useful to check if two nodes are the same. Use it with [`HeaderVec::is`].
     #[inline(always)]
     pub fn ptr(&self) -> *const () {
-        self.ptr as *const ()
+        self.ptr.as_ptr() as *const ()
     }
 
     /// This is used to check if this is the `HeaderVec` that corresponds to the given pointer.
     /// This is useful for updating weak references after [`HeaderVec::push`] returns the pointer.
     #[inline(always)]
     pub fn is(&self, ptr: *const ()) -> bool {
-        self.ptr as *const () == ptr
+        self.ptr.as_ptr() as *const () == ptr
     }
 
     /// Create a (dangerous) weak reference to the `HeaderVec`. This is useful to be able
@@ -300,19 +301,21 @@ impl<H, T> HeaderVec<H, T> {
         // Reallocate the pointer.
         let ptr = unsafe {
             alloc::alloc::realloc(
-                self.ptr as *mut u8,
+                self.ptr.as_ptr() as *mut u8,
                 Self::layout(old_capacity),
                 Self::elems_to_mem_bytes(new_capacity),
             ) as *mut AlignedHeader<H, T>
         };
-        // Handle out-of-memory.
-        if ptr.is_null() {
+
+        let Some(ptr) = NonNull::new(ptr) else {
+            // Handle out-of-memory.
             alloc::alloc::handle_alloc_error(Self::layout(new_capacity));
-        }
+        };
+
         // Check if the new pointer is different than the old one.
         let previous_pointer = if ptr != self.ptr {
             // Give the user the old pointer so they can update everything.
-            Some(self.ptr as *const ())
+            Some(self.ptr())
         } else {
             None
         };
@@ -406,13 +409,13 @@ impl<H, T> HeaderVec<H, T> {
     /// Gets the pointer to the start of the slice.
     #[inline(always)]
     fn start_ptr(&self) -> *const T {
-        unsafe { (self.ptr as *const T).add(Self::offset()) }
+        unsafe { (self.ptr.as_ptr() as *const T).add(Self::offset()) }
     }
 
     /// Gets the pointer to the start of the slice.
     #[inline(always)]
     fn start_ptr_mut(&mut self) -> *mut T {
-        unsafe { (self.ptr as *mut T).add(Self::offset()) }
+        unsafe { (self.ptr.as_ptr() as *mut T).add(Self::offset()) }
     }
 
     /// Gets the pointer to the end of the slice. This returns a mutable pointer to
@@ -425,13 +428,13 @@ impl<H, T> HeaderVec<H, T> {
     #[inline(always)]
     fn header(&self) -> &HeaderVecHeader<H> {
         // The beginning of the memory is always the header.
-        unsafe { &*(self.ptr as *const HeaderVecHeader<H>) }
+        unsafe { &*(self.ptr.as_ptr() as *const HeaderVecHeader<H>) }
     }
 
     #[inline(always)]
     fn header_mut(&mut self) -> &mut HeaderVecHeader<H> {
         // The beginning of the memory is always the header.
-        unsafe { &mut *(self.ptr as *mut HeaderVecHeader<H>) }
+        unsafe { &mut *(self.ptr.as_ptr() as *mut HeaderVecHeader<H>) }
     }
 }
 
@@ -572,7 +575,7 @@ impl<H, T> Drop for HeaderVec<H, T> {
             for ix in 0..self.len_exact() {
                 ptr::drop_in_place(self.start_ptr_mut().add(ix));
             }
-            alloc::alloc::dealloc(self.ptr as *mut u8, Self::layout(self.capacity()));
+            alloc::alloc::dealloc(self.ptr.as_ptr() as *mut u8, Self::layout(self.capacity()));
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -533,16 +533,6 @@ impl<H, T> HeaderVec<H, T> {
         self.header().len.fetch_add(n, Ordering::Release)
     }
 
-    #[inline(always)]
-    pub fn is_empty_atomic_acquire(&self) -> bool {
-        self.len_atomic_acquire() == 0
-    }
-
-    #[inline(always)]
-    pub fn as_slice_atomic_acquire(&self) -> &[T] {
-        unsafe { core::slice::from_raw_parts(self.start_ptr(), self.len_atomic_acquire()) }
-    }
-
     /// Gets the pointer to the end of the slice. This returns a mutable pointer to
     /// uninitialized memory behind the last element.
     #[inline(always)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -255,8 +255,8 @@ impl<H, T> HeaderVec<H, T> {
         self.shrink_to(len)
     }
 
-    /// Resize the vector to have at least room for `additional` more elements.
-    /// does exact resizing if `exact` is true.
+    /// Resize the vector to least `requested_capacity` elements.
+    /// Does exact resizing if `exact` is true.
     ///
     /// Returns `Some(*const ())` if the memory was moved to a new location.
     ///
@@ -265,7 +265,8 @@ impl<H, T> HeaderVec<H, T> {
     /// `requested_capacity` must be greater or equal than `self.len()`
     #[cold]
     unsafe fn resize_cold(&mut self, requested_capacity: usize, exact: bool) -> Option<*const ()> {
-        // For efficiency we do only a debug_assert here
+        // For efficiency we do only a debug_assert here, this is a internal unsafe function
+        // it's contract should be already enforced by the caller which is under our control
         debug_assert!(
             self.len_exact() <= requested_capacity,
             "requested capacity is less than current length"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -381,7 +381,7 @@ impl<H, T> HeaderVec<H, T> {
     const fn offset() -> usize {
         // The first location, in units of size_of::<T>(), that is after the header
         // It's the end of the header, rounded up to the nearest size_of::<T>()
-        (mem::size_of::<AlignedHeader<H, T>>()-1) / mem::size_of::<T>() + 1
+        (mem::size_of::<AlignedHeader<H, T>>() - 1) / mem::size_of::<T>() + 1
     }
 
     /// Compute the number of elements (in units of T) to allocate for a given capacity.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,7 +60,6 @@ impl<H, T> HeaderVec<H, T> {
     }
 
     pub fn with_capacity(capacity: usize, head: H) -> Self {
-        assert!(capacity > 0, "HeaderVec capacity cannot be 0");
         // Allocate the initial memory, which is uninitialized.
         let layout = Self::layout(capacity);
         let ptr = unsafe { alloc::alloc::alloc(layout) } as *mut AlignedHeader<H, T>;
@@ -271,8 +270,6 @@ impl<H, T> HeaderVec<H, T> {
             "requested capacity is less than current length"
         );
         let old_capacity = self.capacity();
-        debug_assert_ne!(old_capacity, 0, "capacity of 0 not yet supported");
-        debug_assert_ne!(requested_capacity, 0, "capacity of 0 not yet supported");
 
         let new_capacity = if requested_capacity > old_capacity {
             if exact {
@@ -281,11 +278,14 @@ impl<H, T> HeaderVec<H, T> {
             } else if requested_capacity <= old_capacity * 2 {
                 // doubling the capacity is sufficient
                 old_capacity * 2
-            } else {
+            } else if old_capacity > 0 {
                 // requested more than twice as much space, reserve the next multiple of
                 // old_capacity that is greater than the requested capacity. This gives headroom
                 // for new inserts while not doubling the memory requirement with bulk requests
                 (requested_capacity / old_capacity + 1).saturating_mul(old_capacity)
+            } else {
+                // special case when we start at capacity 0
+                requested_capacity
             }
         } else if exact {
             // exact shrinking

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -462,8 +462,52 @@ impl<H, T: Clone> HeaderVec<H, T> {
 
 #[cfg(feature = "atomic_append")]
 /// The atomic append API is only enabled when the `atomic_append` feature flag is set (which
-/// is the default).
+/// is the default). The [`push_atomic()`] or [`extend_from_slice_atomic()`] methods then
+/// become available and some internals using atomic operations.
+///
+/// This API implements interior-mutable appending to a shared `HeaderVec`. To other threads
+/// the appended elements are either not seen or all seen at once. Without additional
+/// synchronization these appends are racy but memory safe. The intention behind this API is to
+/// provide facilities for building other container abstractions the benefit from the shared
+/// non blocking nature while being unaffected from the racy semantics or provide synchronization
+/// on their own (Eg: reference counted data, interners, streaming parsers, etc). Since the
+/// `HeaderVec` is a shared object and we have only a `&self`, it can not be reallocated and moved,
+/// therefore appending can only be done within the reserved capacity.
+///
+/// # Safety
+///
+/// Only one single thread must try to [`push_atomic()`] or [`extend_from_slice_atomic()`] the
+/// `HeaderVec` at at time using the atomic append API's. The actual implementations of this
+/// restriction is left to the caller.  This can be done by mutexes or guard objects. Or
+/// simply by staying single threaded or ensuring somehow else that there is only a single
+/// thread using the atomic_appending API.
 impl<H, T> HeaderVec<H, T> {
+    /// Atomically adds an item to the end of the list without reallocation.
+    ///
+    /// # Errors
+    ///
+    /// If the vector is full, the item is returned.
+    ///
+    /// # Safety
+    ///
+    /// There must be only one thread calling this method at any time. Synchronization has to
+    /// be provided by the user.
+    pub unsafe fn push_atomic(&self, item: T) -> Result<(), T> {
+        // relaxed is good enough here because this should be the only thread calling this method.
+        let len = self.len_atomic_relaxed();
+        if len < self.capacity() {
+            unsafe {
+                core::ptr::write(self.end_ptr_atomic_mut(), item);
+            };
+            let len_again = self.len_atomic_add_release(1);
+            // in debug builds we check for races, the chance to catch these are still pretty minimal
+            debug_assert_eq!(len_again, len, "len was updated by another thread");
+            Ok(())
+        } else {
+            Err(item)
+        }
+    }
+
     /// Get the length of the vector with `Ordering::Acquire`. This ensures that the length is
     /// properly synchronized after it got atomically updated.
     #[inline(always)]
@@ -504,32 +548,6 @@ impl<H, T> HeaderVec<H, T> {
     #[inline(always)]
     fn end_ptr_atomic_mut(&self) -> *mut T {
         unsafe { self.start_ptr().add(self.len_atomic_acquire()) as *mut T }
-    }
-
-    /// Atomically adds an item to the end of the list without reallocation.
-    ///
-    /// # Errors
-    ///
-    /// If the vector is full, the item is returned.
-    ///
-    /// # Safety
-    ///
-    /// There must be only one thread calling this method at any time. Synchronization has to
-    /// be provided by the user.
-    pub unsafe fn push_atomic(&self, item: T) -> Result<(), T> {
-        // relaxed is good enough here because this should be the only thread calling this method.
-        let len = self.len_atomic_relaxed();
-        if len < self.capacity() {
-            unsafe {
-                core::ptr::write(self.end_ptr_atomic_mut(), item);
-            };
-            let len_again = self.len_atomic_add_release(1);
-            // in debug builds we check for races, the chance to catch these are still pretty minimal
-            debug_assert_eq!(len_again, len, "len was updated by another thread");
-            Ok(())
-        } else {
-            Err(item)
-        }
     }
 }
 

--- a/tests/atomic_append.rs
+++ b/tests/atomic_append.rs
@@ -1,0 +1,16 @@
+#![cfg(feature = "atomic_append")]
+extern crate std;
+
+use header_vec::*;
+
+#[test]
+fn test_atomic_append() {
+    let mut hv = HeaderVec::with_capacity(10, ());
+
+    hv.push(1);
+    unsafe { hv.push_atomic(2).unwrap() };
+    hv.push(3);
+
+    assert_eq!(hv.len(), 3);
+    assert_eq!(hv.as_slice(), [1, 2, 3]);
+}

--- a/tests/atomic_append.rs
+++ b/tests/atomic_append.rs
@@ -14,3 +14,14 @@ fn test_atomic_append() {
     assert_eq!(hv.len(), 3);
     assert_eq!(hv.as_slice(), [1, 2, 3]);
 }
+
+#[test]
+fn test_extend_from_slice() {
+    let hv = HeaderVec::with_capacity(6, ());
+
+    unsafe {
+        hv.extend_from_slice_atomic(&[0, 1, 2]).unwrap();
+        hv.extend_from_slice_atomic(&[3, 4, 5]).unwrap();
+    }
+    assert_eq!(hv.as_slice(), &[0, 1, 2, 3, 4, 5]);
+}

--- a/tests/simple.rs
+++ b/tests/simple.rs
@@ -53,3 +53,12 @@ fn test_push() {
     hv.push(123);
     assert_eq!(hv[0], 123);
 }
+
+#[test]
+fn test_extend_from_slice() {
+    let mut hv = HeaderVec::new(());
+
+    hv.extend_from_slice(&[0, 1, 2]);
+    hv.extend_from_slice(&[3, 4, 5]);
+    assert_eq!(hv.as_slice(), &[0, 1, 2, 3, 4, 5]);
+}

--- a/tests/simple.rs
+++ b/tests/simple.rs
@@ -44,3 +44,12 @@ fn test_head_array() {
         v_orig.as_slice().iter().copied().collect::<String>()
     );
 }
+
+// This shown a miri error
+#[test]
+fn test_push() {
+    let mut hv = HeaderVec::with_capacity(10, ());
+
+    hv.push(123);
+    assert_eq!(hv[0], 123);
+}

--- a/tests/simple.rs
+++ b/tests/simple.rs
@@ -12,6 +12,17 @@ struct TestA {
 }
 
 #[test]
+fn test_empty() {
+    let mut v_empty = HeaderVec::with_capacity(0, TestA { a: 4, b: !0, c: 66 });
+
+    assert_eq!(0, v_empty.len());
+    assert_eq!(0, v_empty.capacity());
+    assert_eq!(0, v_empty.as_slice().len());
+
+    v_empty.extend_from_slice("the quick brown fox jumps over the lazy dog".as_bytes());
+}
+
+#[test]
 fn test_head_array() {
     let mut v_orig = HeaderVec::new(TestA { a: 4, b: !0, c: 66 });
 

--- a/tests/simple.rs
+++ b/tests/simple.rs
@@ -12,6 +12,20 @@ struct TestA {
 }
 
 #[test]
+fn test_sizeof() {
+    // assert that HeaderVec is really a single lean pointer
+    assert_eq!(
+        core::mem::size_of::<HeaderVec<(), ()>>(),
+        core::mem::size_of::<*mut ()>()
+    );
+    // and has space for niche optimization
+    assert_eq!(
+        core::mem::size_of::<HeaderVec<(), ()>>(),
+        core::mem::size_of::<Option<HeaderVec<(), ()>>>()
+    );
+}
+
+#[test]
 fn test_head_array() {
     let mut v_orig = HeaderVec::new(TestA { a: 4, b: !0, c: 66 });
 


### PR DESCRIPTION
While my `atomic append` PR #10 targets appending to a shared headervec through a immutable reference (rather special use case), this implements the std vec like way using a mutable reference to a headervec using the spare capacity as a writable buffer and then completing this by readjusting the len.

note: this includes all work on #10